### PR TITLE
1.19 update baseline fixes

### DIFF
--- a/Block/BlockBottle.cs
+++ b/Block/BlockBottle.cs
@@ -84,11 +84,11 @@
             if (this.Code.Path.Contains("clay"))
             { return; }
 
-            Dictionary<int, MeshRef> meshrefs;
+            Dictionary<int, MultiTextureMeshRef> meshrefs;
             if (capi.ObjectCache.TryGetValue(this.MeshRefsCacheKey, out var obj))
-            { meshrefs = obj as Dictionary<int, MeshRef>; }
+            { meshrefs = obj as Dictionary<int, MultiTextureMeshRef>; }
             else
-            { capi.ObjectCache[this.MeshRefsCacheKey] = meshrefs = new Dictionary<int, MeshRef>(); }
+            { capi.ObjectCache[this.MeshRefsCacheKey] = meshrefs = new Dictionary<int, MultiTextureMeshRef>(); }
 
             var contentStack = this.GetContent(itemstack);
             if (contentStack == null)
@@ -98,7 +98,7 @@
             if (!meshrefs.TryGetValue(hashcode, out var meshRef))
             {
                 var meshdata = this.GenMesh(capi, contentStack);
-                meshrefs[hashcode] = meshRef = capi.Render.UploadMesh(meshdata);
+                meshrefs[hashcode] = meshRef = capi.Render.UploadMultiTextureMesh(meshdata);
             }
             renderinfo.ModelRef = meshRef;
         }

--- a/Block/BlockBottle.cs
+++ b/Block/BlockBottle.cs
@@ -134,7 +134,7 @@
 
             if (capi.ObjectCache.TryGetValue(this.MeshRefsCacheKey, out var obj))
             {
-                var meshrefs = obj as Dictionary<int, MeshRef>;
+                var meshrefs = obj as Dictionary<int, MultiTextureMeshRef>;
                 foreach (var val in meshrefs)
                 { val.Value.Dispose(); }
                 capi.ObjectCache.Remove(this.MeshRefsCacheKey);

--- a/Block/BlockExpandedClayOven.cs
+++ b/Block/BlockExpandedClayOven.cs
@@ -125,7 +125,12 @@ namespace ACulinaryArtillery
 
             return base.OnBlockInteractStart(world, byPlayer, bs);
         }
-
+        EnumIgniteState IIgnitable.OnTryIgniteStack(EntityAgent byEntity, BlockPos pos, ItemSlot slot, float secondsIgniting)
+        {
+            BlockEntityExpandedOven beo = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityExpandedOven;
+            if (beo.IsBurning) return secondsIgniting > 2 ? EnumIgniteState.IgniteNow : EnumIgniteState.Ignitable;
+            return EnumIgniteState.NotIgnitable;
+        }
         public EnumIgniteState OnTryIgniteBlock(EntityAgent byEntity, BlockPos pos, float secondsIgniting)
         {
             BlockEntityExpandedOven beo = byEntity.World.BlockAccessor.GetBlockEntity(pos) as BlockEntityExpandedOven;

--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -664,17 +664,17 @@ namespace ACulinaryArtillery
 
         public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
         {
-            Dictionary<int, MeshRef> meshrefs = null;
+            Dictionary<int, MultiTextureMeshRef> meshrefs = null;
             bool isSealed = itemstack.Attributes.GetBool("isSealed");
 
             object obj;
             if (capi.ObjectCache.TryGetValue((Variant["metal"]) + "MeshRefs", out obj))
             {
-                meshrefs = obj as Dictionary<int, MeshRef>;
+                meshrefs = obj as Dictionary<int, MultiTextureMeshRef>;
             }
             else
             {
-                capi.ObjectCache[(Variant["metal"]) + "MeshRefs"] = meshrefs = new Dictionary<int, MeshRef>();
+                capi.ObjectCache[(Variant["metal"]) + "MeshRefs"] = meshrefs = new Dictionary<int, MultiTextureMeshRef>();
             }
 
             ItemStack contentStack = GetContent(itemstack);
@@ -682,7 +682,7 @@ namespace ACulinaryArtillery
 
             int hashcode = GetSaucepanHashCode(capi.World, contentStack, isSealed);
 
-            MeshRef meshRef = null;
+            MultiTextureMeshRef meshRef = null;
 
             if (!meshrefs.TryGetValue(hashcode, out meshRef))
             {
@@ -690,7 +690,7 @@ namespace ACulinaryArtillery
                 //meshdata.Rgba2 = null;
 
 
-                meshrefs[hashcode] = meshRef = capi.Render.UploadMesh(meshdata);
+                meshrefs[hashcode] = meshRef = capi.Render.UploadMultiTextureMesh(meshdata);
 
             }
 

--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -544,20 +544,20 @@ namespace ACulinaryArtillery
             if (ings == null || ings.Length <= 0)
                 return;
 
-            Dictionary<string, MeshRef> meshrefs = ObjectCacheUtil.GetOrCreate(capi, "expandedFoodGuiMeshRefs", () =>
+            Dictionary<string, MultiTextureMeshRef> meshrefs = ObjectCacheUtil.GetOrCreate(capi, "expandedFoodGuiMeshRefs", () =>
             {
-                return new Dictionary<string, MeshRef>();
+                return new Dictionary<string, MultiTextureMeshRef>();
             });
 
             string key = Code.ToShortString() + string.Join("|", ings);
-            MeshRef meshref;
+            MultiTextureMeshRef meshref;
             if (!meshrefs.TryGetValue(key, out meshref))
             {
                 MeshData mesh = GenMesh(capi.ItemTextureAtlas, ings, new Vec3f(0, 0, 0));
                 if (mesh == null)
                     return;
 
-                meshrefs[key] = meshref = capi.Render.UploadMesh(mesh);
+                meshrefs[key] = meshref = capi.Render.UploadMultiTextureMesh(mesh);
             }
 
             if (meshref != null)


### PR DESCRIPTION
Basic changes and update to make the mod load correctly with 1.19 (as of 1.19 RC 4).

Added missing implements for BlockExpandedClayOven for IIgnitable and swapped over the old MeshRef and UploadMesh() for the new MultiTextureMeshRef and UploadMultiTextureMeshRef() where applicable.

Tested on 1.19 RC 4 on a new creative world. 

Logs attached for server and client main. Also checked associated Debug logs and nothing unusual there.
[client-main.txt](https://github.com/l33tmaan/ACulinaryArtillery---.NET7/files/13799164/client-main.txt)
[server-main.txt](https://github.com/l33tmaan/ACulinaryArtillery---.NET7/files/13799165/server-main.txt)
