### PR TITLE
Egg crash fix + dedicated server display/harmony patch not loading on subsequent loads fix

### DIFF
--- a/ACulinaryArtillery.cs
+++ b/ACulinaryArtillery.cs
@@ -18,7 +18,7 @@ namespace ACulinaryArtillery
 
         public override void Start(ICoreAPI api)
         {
-            base.Start(api);
+            //base.Start(api);
 
             api.RegisterBlockClass("BlockMeatHooks", typeof(BlockMeatHooks));
             api.RegisterBlockEntityClass("MeatHooks", typeof(BlockEntityMeatHooks));
@@ -78,7 +78,8 @@ namespace ACulinaryArtillery
             logger = api.Logger;
 
             if (harmony is null) {
-                harmony = new Harmony("com.jakecool19.efrecipes.cookingoverhaul"); 
+                harmony = new Harmony("com.jakecool19.efrecipes.cookingoverhaul");
+                
             }
             harmony.PatchAll(Assembly.GetExecutingAssembly());
 
@@ -88,11 +89,11 @@ namespace ACulinaryArtillery
         {
             logger.Debug("Unpatching harmony methods");
             harmony.UnpatchAll(harmony.Id);
-            base.Dispose();
+            //base.Dispose();
         }
         public override void StartServerSide(ICoreServerAPI api)
         {
-            base.StartServerSide(api);
+            //base.StartServerSide(api);
 
             api.RegisterCommand("efremap", "Remaps items in Expanded Foods", "",
                 //This can't possibly work XD

--- a/ACulinaryArtillery.cs
+++ b/ACulinaryArtillery.cs
@@ -1,7 +1,9 @@
 ﻿using ACulinaryArtillery.Util;
 using HarmonyLib;
 using System;
+using System.Linq;
 using System.Reflection;
+using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
@@ -16,7 +18,7 @@ namespace ACulinaryArtillery
 
         public override void Start(ICoreAPI api)
         {
-            //base.Start(api);
+            base.Start(api);
 
             api.RegisterBlockClass("BlockMeatHooks", typeof(BlockMeatHooks));
             api.RegisterBlockEntityClass("MeatHooks", typeof(BlockEntityMeatHooks));
@@ -74,26 +76,23 @@ namespace ACulinaryArtillery
             }
 
             logger = api.Logger;
-            
+
             if (harmony is null) {
-                /* there seems to be *repeated* calls to "Start" for the same process. 
-                 * Make sure we dont try to double/triple patch things (where we would possibly 
-                 * not find things as expected on the repeated attempts)                        */
-                harmony = new Harmony("com.jakecool19.efrecipes.cookingoverhaul");
-                harmony.PatchAll(Assembly.GetExecutingAssembly());
+                harmony = new Harmony("com.jakecool19.efrecipes.cookingoverhaul"); 
             }
+            harmony.PatchAll(Assembly.GetExecutingAssembly());
 
         }
 
         public override void Dispose()
         {
+            logger.Debug("Unpatching harmony methods");
             harmony.UnpatchAll(harmony.Id);
-            //base.Dispose();
+            base.Dispose();
         }
-
         public override void StartServerSide(ICoreServerAPI api)
         {
-            //base.StartServerSide(api);
+            base.StartServerSide(api);
 
             api.RegisterCommand("efremap", "Remaps items in Expanded Foods", "",
                 //This can't possibly work XD

--- a/Block/BlockBottle.cs
+++ b/Block/BlockBottle.cs
@@ -31,7 +31,11 @@
 
         public AssetLocation liquidFillSoundLocation => new AssetLocation("game:sounds/effect/water-fill");
         public AssetLocation liquidDrinkSoundLocation => new AssetLocation("game:sounds/player/drink1");
-
+        public override byte[] GetLightHsv(IBlockAccessor blockAccessor, BlockPos pos, ItemStack stack = null)
+        {
+            //api.Logger.Debug("Getting Light HSV for: " + stack + " | " + this.GetContent(stack) + "|" + this.GetContent(stack)?.Item?.LightHsv?.ToString());
+            return this.GetContent(stack)?.Item?.LightHsv ?? base.GetLightHsv(blockAccessor, pos, stack);
+        }
         public override void OnLoaded(ICoreAPI api)
         {
             base.OnLoaded(api);

--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -22,7 +22,7 @@ namespace ACulinaryArtillery
         public override bool AllowHeldLiquidTransfer => true;
         public AssetLocation liquidFillSoundLocation => new AssetLocation("game:sounds/effect/water-fill");
 
-        private List<SimmerRecipe> simmerRecipes = MixingRecipeRegistry.Registry.SimmerRecipes;
+        private List<SimmerRecipe> simmerRecipes => MixingRecipeRegistry.Registry.SimmerRecipes;
 
         public bool isSealed;
         public override void OnLoaded(ICoreAPI api)
@@ -124,7 +124,6 @@ namespace ACulinaryArtillery
         {
             if (!CanSmelt(world, cookingSlotsProvider, inputSlot.Itemstack, outputSlot.Itemstack))
                 return;
-
             List<ItemStack> contents = new List<ItemStack>();   //The inputSlots may not all be filled. This is more convenient.
             ItemStack product = null;
 

--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -124,6 +124,7 @@ namespace ACulinaryArtillery
         {
             if (!CanSmelt(world, cookingSlotsProvider, inputSlot.Itemstack, outputSlot.Itemstack))
                 return;
+
             List<ItemStack> contents = new List<ItemStack>();   //The inputSlots may not all be filled. This is more convenient.
             ItemStack product = null;
 
@@ -156,7 +157,7 @@ namespace ACulinaryArtillery
 
                 if (match == null) //none of the recipes matched
                     return;
-
+                match.Simmering.SmeltedStack.Resolve(world, "Saucepansimmerrecipesmeltstack");
                 product = match.Simmering.SmeltedStack.ResolvedItemstack.Clone();
 
                 product.StackSize *= amountForTheseIngredients;
@@ -186,7 +187,10 @@ namespace ACulinaryArtillery
 
             if (product == null)    //if we have no output to give
                 return;
-
+            //ACulinaryArtillery.logger.Debug("Product: " + product?.ToString());
+           // ACulinaryArtillery.logger.Debug("Itemstack class: " + product?.Class.ToString());
+            //ACulinaryArtillery.logger.Debug("Product class: " + product?.Collectible?.Class?.ToString());
+           // ACulinaryArtillery.logger.Debug("Product: " + product.GetName() + " Is liquid?: " + (product.Collectible.Class == "ItemLiquidPortion" || product.Collectible is ItemExpandedLiquid || product.Collectible is ItemTransLiquid));
             if (product.Collectible.Class == "ItemLiquidPortion" || product.Collectible is ItemExpandedLiquid || product.Collectible is ItemTransLiquid)
             {
                 for (int i = 0; i < cookingSlotsProvider.Slots.Length; i++)
@@ -195,7 +199,7 @@ namespace ACulinaryArtillery
                 }
 
                 outputSlot.Itemstack = inputSlot.TakeOut(1);
-
+                //ACulinaryArtillery.logger.Debug("OutputSlot: " + outputSlot.Itemstack.GetName());
                 (outputSlot.Itemstack.Collectible as BlockLiquidContainerBase).TryPutLiquid(outputSlot.Itemstack, product, product.StackSize);
 
             }

--- a/Item/ItemEggCrack.cs
+++ b/Item/ItemEggCrack.cs
@@ -103,8 +103,11 @@ namespace ACulinaryArtillery
             }
             else
             {
-                EnumHandling passThroughHandling = EnumHandling.PreventDefault;
-                slot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>().OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling, ref passThroughHandling);
+                //ACulinaryArtillery.logger.Debug("Cant crack: " + slot.Itemstack.ToString());
+                //EnumHandling passThroughHandling = EnumHandling.PreventDefault;
+                handling = EnumHandHandling.PreventDefault;
+                base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling);
+                //slot.Itemstack.Collectible.GetBehavior<CollectibleBehaviorGroundStorable>().OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handling, ref passThroughHandling);
             }
         }
 

--- a/Util/Patches.cs
+++ b/Util/Patches.cs
@@ -33,12 +33,12 @@ namespace ACulinaryArtillery
         //}
 
         [HarmonyPostfix]
-        [HarmonyPatch(typeof(InventorySmelting),nameof(InventorySmelting.GetOutputText))]
-         static void displayFix(ref string __result, ItemSlot[] ___slots, ref InventorySmelting __instance)
-         {
-             if (___slots[1].Itemstack?.Collectible is BlockSaucepan)
+        [HarmonyPatch("GetOutputText")]
+        static void displayFix(ref string __result, InventorySmelting __instance)
+        {
+            if (__instance[1].Itemstack?.Collectible is BlockSaucepan)
             {
-                __result = (___slots[1].Itemstack.Collectible as BlockSaucepan).GetOutputText(__instance.Api.World, __instance);
+                __result = (__instance[1].Itemstack.Collectible as BlockSaucepan).GetOutputText(__instance.Api.World, __instance);
             }
         }
 

--- a/Util/Patches.cs
+++ b/Util/Patches.cs
@@ -33,12 +33,12 @@ namespace ACulinaryArtillery
         //}
 
         [HarmonyPostfix]
-        [HarmonyPatch("GetOutputText")]
-         static void displayFix(ref string __result, InventorySmelting __instance)
+        [HarmonyPatch(typeof(InventorySmelting),nameof(InventorySmelting.GetOutputText))]
+         static void displayFix(ref string __result, ItemSlot[] ___slots, ref InventorySmelting __instance)
          {
-             if (__instance[1].Itemstack?.Collectible is BlockSaucepan)
-             {
-                 __result = (__instance[1].Itemstack.Collectible as BlockSaucepan).GetOutputText(__instance.Api.World, __instance);
+             if (___slots[1].Itemstack?.Collectible is BlockSaucepan)
+            {
+                __result = (___slots[1].Itemstack.Collectible as BlockSaucepan).GetOutputText(__instance.Api.World, __instance);
             }
         }
 


### PR DESCRIPTION
-Changed default condition for itemEggCrack to call the base method rather than always trying to call a behaviorGroundStorables (resulting in nullrefs)
-Removed check for harmony object in `Start()` as it was preventing harmony patches from being loaded if a client had left a world then joined another without restarting their game completely
-Made blockSaucepans simmeringRecipeList use expression body definition to have an always up to date list, instead of just setting it on initialization (this was resulting in a client-side list of 0 entries as it was being set before the server had synced the recipes to the client)