### PR TITLE
Fix? For Item ID outside of range crash

### DIFF
--- a/Util/RecipeSystem.cs
+++ b/Util/RecipeSystem.cs
@@ -377,10 +377,14 @@ namespace ACulinaryArtillery
         public override void StartServerSide(ICoreServerAPI api)
         {
             this.api = api;
+
         }
 
         public override void AssetsFinalize(ICoreAPI api)
         {
+            MixingRecipeRegistry.Registry.MixingRecipes.Clear();
+            MixingRecipeRegistry.Registry.KneadingRecipes.Clear();
+            MixingRecipeRegistry.Registry.SimmerRecipes.Clear();
             LoadFoodRecipes();
         }
 


### PR DESCRIPTION
The crash was occurring due to the recipe registries always `adding` recipes without ever clearing. 

This was causing behavior where recipes would be loaded with `serialized itemids` that were not valid in the world they were being `deserialized` in along side the same recipes with the correct ids for the world. 

This was especially noticeable if a player had two different worlds with different modsets, loading into the one with a higher max range of itemIds, then loading into the one with a lower max range of itemIds, would cause two sets of all the recipe ingredients in the registry (mainly focusing on those for DoughIngredient), with one set having the former worlds IDs, and the other with the latter worlds IDs. These then get serialized by the server and sent to the client. When trying to deserialize them on the client, it would attempt to get an itemstack of one of those former ids and crash.

(untested) In instances where a crash would not happen this perhaps would also create wrong outputs as an item would be created with the wrong id than expected.