### PR TITLE
Fix for bugged rendering of cauldrons in the firepit, resulting in mismatched or randomized textures

### DIFF
--- a/Renderer/SaucepanInFirepitRenderer.cs
+++ b/Renderer/SaucepanInFirepitRenderer.cs
@@ -73,7 +73,6 @@ namespace ACulinaryArtillery
 
             IStandardShaderProgram prog = rpi.PreparedStandardShader(pos.X, pos.Y, pos.Z);
 
-            prog.Tex2D = capi.BlockTextureAtlas.AtlasTextures[0].TextureId;
             prog.DontWarpVertices = 0;
             prog.AddRenderFlags = 0;
             prog.RgbaAmbientIn = rpi.AmbientColor;
@@ -98,7 +97,7 @@ namespace ACulinaryArtillery
             prog.ViewMatrix = rpi.CameraMatrixOriginf;
             prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
 
-            rpi.RenderMultiTextureMesh(saucepanRef);
+            rpi.RenderMultiTextureMesh(saucepanRef, "tex");
 
             if (!isInOutputSlot)
             {
@@ -121,7 +120,7 @@ namespace ACulinaryArtillery
                 prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
 
 
-                rpi.RenderMultiTextureMesh(topRef);
+                rpi.RenderMultiTextureMesh(topRef, "tex");
             }
 
             prog.Stop();


### PR DESCRIPTION
This was caused by a hardcoded shader texture bind to only the first BlockTextureAtlas. In instances where players had filled that first atlas due to high texture count or configured a smaller atlas size, the textures needed for the cauldrons could be located in one of the successive atlases. This lead to the shader referencing (I think?) the correct position of the texture, but on the wrong atlas, and as such a seemingly random texture was rendered. 

Simply removing the hardcoded binding and relying on the dynamic binding contained within the overloaded `RenderMultiTextureMesh(meshRef, textureSampleName)` seems to fix it entirely.