### PR TITLE
v1.20.pre API changes

### DIFF
--- a/Block Entity/BEBottle.cs
+++ b/Block Entity/BEBottle.cs
@@ -1,11 +1,11 @@
-﻿namespace ACulinaryArtillery
+﻿using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.GameContent;
+
+namespace ACulinaryArtillery
 {
-    using Vintagestory.API.Client;
-    using Vintagestory.API.Common;
-    using Vintagestory.API.Datastructures;
-    using Vintagestory.API.MathTools;
-    using Vintagestory.GameContent;
-    //using System.Diagnostics;
 
     public class BlockEntityBottle : BlockEntityContainer
     {
@@ -29,8 +29,16 @@
                 this.currentMesh = this.GenMesh();
                 this.MarkDirty(true);
             }
+
+            Inventory.OnAcquireTransitionSpeed += Inventory_OnAcquireTransitionSpeed1;
         }
 
+        private float Inventory_OnAcquireTransitionSpeed1(EnumTransitionType transType, ItemStack stack, float mulByConfig)
+        {
+            var mul = Inventory.GetTransitionSpeedMul(transType, stack);
+            mul *= this.ownBlock?.GetContainingTransitionModifierPlaced(this.Api.World, this.Pos, transType) ?? 1;
+            return mul;
+        }
 
         public override void OnBlockPlaced(ItemStack byItemStack = null)
         {
@@ -83,14 +91,6 @@
             { return false; }
             mesher.AddMeshData(this.currentMesh.Clone().Rotate(new Vec3f(0.5f, 0.5f, 0.5f), 0, 0, 0));
             return true;
-        }
-
-
-        protected override float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float baseMul)
-        {
-            var mul = base.Inventory_OnAcquireTransitionSpeed(transType, stack, baseMul);
-            mul *= this.ownBlock?.GetContainingTransitionModifierPlaced(this.Api.World, this.Pos, transType) ?? 1;
-            return mul;
         }
     }
 }

--- a/Block Entity/BEMixingBowl.cs
+++ b/Block Entity/BEMixingBowl.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -528,13 +527,13 @@ namespace ACulinaryArtillery
         {
             if (blockSel.SelectionBoxIndex == 1) return false;
 
+            
             if (Api.World is IServerWorldAccessor)
             {
                 ((ICoreServerAPI)Api).Network.SendBlockEntityPacket(
                     (IServerPlayer)byPlayer,
-                    Pos.X, Pos.Y, Pos.Z,
-                    (int)EnumBlockStovePacket.OpenGUI,
-                    null
+                    Pos,
+                    (int)EnumBlockStovePacket.OpenGUI
                 );
 
                 byPlayer.InventoryManager.OpenInventory(inventory);

--- a/Block Entity/BlockEntityMeatHooks.cs
+++ b/Block Entity/BlockEntityMeatHooks.cs
@@ -28,6 +28,19 @@ namespace ACulinaryArtillery
         {
             base.Initialize(api);
             RegisterGameTickListener(RotDrop, 3000);
+
+            Inventory.OnAcquireTransitionSpeed += Inventory_OnAcquireTransitionSpeed1; ;
+        }
+
+        private float Inventory_OnAcquireTransitionSpeed1(EnumTransitionType transType, ItemStack stack, float mulByConfig)
+        {
+            if (Api == null) return 1;
+
+            if (transType == EnumTransitionType.Cure) return Block.Attributes["cureRate"].AsFloat(3);
+            if (transType == EnumTransitionType.Dry) return Block.Attributes["dryRate"].AsFloat(3);
+
+
+            return Inventory.GetTransitionSpeedMul(transType, stack);
         }
 
         private void RotDrop(float dt)
@@ -69,18 +82,6 @@ namespace ACulinaryArtillery
 
 
             return false;
-        }
-
-        protected override float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float baseMul)
-        {
-            if (Api == null) return 1;
-
-            if (transType == EnumTransitionType.Cure) return Block.Attributes["cureRate"].AsFloat(3);
-            if (transType == EnumTransitionType.Dry) return Block.Attributes["dryRate"].AsFloat(3);
-
-
-            return base.Inventory_OnAcquireTransitionSpeed(transType, stack, baseMul);
-
         }
 
         private bool TryPut(ItemSlot slot, BlockSelection blockSel)

--- a/Block Entity/BlockEntitySaucepan.cs
+++ b/Block Entity/BlockEntitySaucepan.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using ACulinaryArtillery.Block_Entity;
+using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
-using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
-using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
 
 namespace ACulinaryArtillery
@@ -18,6 +16,7 @@ namespace ACulinaryArtillery
 
         public override void Initialize(ICoreAPI api)
         {
+            container = new BlockEntitySaucepanContainer(this, () => Inventory, "inventory");
             base.Initialize(api);
 
             ownBlock = Block as BlockSaucepan;
@@ -101,12 +100,6 @@ namespace ACulinaryArtillery
             {
                 currentRightMesh = GenRightMesh();
             }
-        }
-
-
-        public override float GetPerishRate()
-        {
-            return base.GetPerishRate() * (isSealed ? Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
         }
     }
 }

--- a/Block Entity/BlockEntitySaucepanContainer.cs
+++ b/Block Entity/BlockEntitySaucepanContainer.cs
@@ -1,0 +1,18 @@
+﻿using Vintagestory.GameContent;
+
+namespace ACulinaryArtillery.Block_Entity
+{
+    public class BlockEntitySaucepanContainer : InWorldContainer
+    {
+        private BlockEntitySaucepan blockEntitySaucepan;
+        public BlockEntitySaucepanContainer(BlockEntitySaucepan blockEntitySaucepan, InventorySupplierDelegate inventorySupplier, string treeAttrKey): base(inventorySupplier, treeAttrKey)
+        {
+            this.blockEntitySaucepan = blockEntitySaucepan;
+        }
+
+        public override float GetPerishRate()
+        {
+            return GetPerishRate() * (blockEntitySaucepan.isSealed ? blockEntitySaucepan.Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
+        }
+    }
+}

--- a/Block Entity/BlockEntitySaucepanContainer.cs
+++ b/Block Entity/BlockEntitySaucepanContainer.cs
@@ -12,7 +12,7 @@ namespace ACulinaryArtillery.Block_Entity
 
         public override float GetPerishRate()
         {
-            return GetPerishRate() * (blockEntitySaucepan.isSealed ? blockEntitySaucepan.Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
+            return base.GetPerishRate() * (blockEntitySaucepan.isSealed ? blockEntitySaucepan.Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
         }
     }
 }


### PR DESCRIPTION
Hello, this PR should fix API changes introduced in 1.20.pre update. I have no previous experience with modding Vintage Story, only C# in general and modding here and there for some other games. From some basic testing it seems to work. I am not 100% sure about the new way of GetPerishRate() implementation and also about the new OnAcquireTransitionSpeed event handler.

Fixed crash when opening Mixing Bowl inventory.

Cheers!