### PR TITLE
Initial 1.20 Fixes/Changes

### DIFF
--- a/ACulinaryArtillery.cs
+++ b/ACulinaryArtillery.cs
@@ -44,7 +44,6 @@ namespace ACulinaryArtillery
             //api.RegisterBlockEntityClass("ExpandedOvenOLD", typeof(BlockEntityExpandedOvenOLD));
 
             api.RegisterBlockEntityClass("ExpandedOven", typeof(BlockEntityExpandedOven));
-
             api.RegisterItemClass("SuperFood", typeof(ItemSuperFood));
             api.RegisterItemClass("EggCrack", typeof(ItemEggCrack));
             api.RegisterItemClass("ExpandedRawFood", typeof(ItemExpandedRawFood));

--- a/ACulinaryArtillery.csproj
+++ b/ACulinaryArtillery.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>bin\$(Configuration)\Mods</OutputPath>
+    <OutputPath>bin\$(Configuration)\Mods\mod</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>false</Optimize>
   </PropertyGroup>

--- a/Block Entity/BEBottle.cs
+++ b/Block Entity/BEBottle.cs
@@ -23,7 +23,7 @@
         {
             base.Initialize(api);
             this.ownBlock = this.Block as BlockBottle;
-
+            this.Inventory.OnAcquireTransitionSpeed += Inventory_OnAcquireTransitionSpeed1;
             if (this.Api.Side == EnumAppSide.Client)
             {
                 this.currentMesh = this.GenMesh();
@@ -35,7 +35,6 @@
         public override void OnBlockPlaced(ItemStack byItemStack = null)
         {
             base.OnBlockPlaced(byItemStack);
-
             if (this.Api.Side == EnumAppSide.Client)
             {
                 this.currentMesh = this.GenMesh();
@@ -43,6 +42,11 @@
             }
         }
 
+        private float Inventory_OnAcquireTransitionSpeed1(EnumTransitionType transType, ItemStack stack, float baseMul)
+        {
+            float mul = baseMul * this.ownBlock?.GetContainingTransitionModifierPlaced(this.Api.World, this.Pos, transType) ?? 1;
+            return mul;
+        }
 
         public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldForResolving)
         {
@@ -85,12 +89,13 @@
             return true;
         }
 
-
+        /*
         protected override float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float baseMul)
         {
             var mul = base.Inventory_OnAcquireTransitionSpeed(transType, stack, baseMul);
             mul *= this.ownBlock?.GetContainingTransitionModifierPlaced(this.Api.World, this.Pos, transType) ?? 1;
             return mul;
         }
+        */
     }
 }

--- a/Block Entity/BEMixingBowl.cs
+++ b/Block Entity/BEMixingBowl.cs
@@ -532,9 +532,8 @@ namespace ACulinaryArtillery
             {
                 ((ICoreServerAPI)Api).Network.SendBlockEntityPacket(
                     (IServerPlayer)byPlayer,
-                    Pos.X, Pos.Y, Pos.Z,
-                    (int)EnumBlockStovePacket.OpenGUI,
-                    null
+                    Pos,
+                    (int)EnumBlockStovePacket.OpenGUI
                 );
 
                 byPlayer.InventoryManager.OpenInventory(inventory);

--- a/Block Entity/BESaucepanContainer.cs
+++ b/Block Entity/BESaucepanContainer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vintagestory.GameContent;
+
+namespace ACulinaryArtillery.Block_Entity
+{
+    public class BESaucepanContainer : InWorldContainer
+    {
+        private BlockEntitySaucepan BESaucepan;
+        public BESaucepanContainer(BlockEntitySaucepan blockEntitySaucepan, InventorySupplierDelegate inventorySupplier, string treeAttrKey) : base(inventorySupplier, treeAttrKey)
+        {
+            this.BESaucepan = blockEntitySaucepan;
+        }
+        public override float GetPerishRate()
+        {
+            return base.GetPerishRate() * (BESaucepan.isSealed ? BESaucepan.Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
+        }
+    }
+}

--- a/Block Entity/BlockEntityBottleRack.cs
+++ b/Block Entity/BlockEntityBottleRack.cs
@@ -15,7 +15,7 @@ namespace ACulinaryArtillery
     {
         private readonly int maxSlots = 16;
         public override string InventoryClassName => "bottlerack";
-        protected InventoryGeneric inventory;
+        //protected InventoryGeneric inventory;
 
         public override InventoryBase Inventory => this.inventory;
 

--- a/Block Entity/BlockEntityMeatHooks.cs
+++ b/Block Entity/BlockEntityMeatHooks.cs
@@ -13,7 +13,7 @@ namespace ACulinaryArtillery
     public class BlockEntityMeatHooks : BlockEntityDisplayCase, ITexPositionSource
     {
         public override string InventoryClassName => "meathooks";
-        protected InventoryGeneric inventory;
+        //protected InventoryGeneric inventory;
         public override string AttributeTransformCode => "meatHookTransform";
         public override InventoryBase Inventory => inventory;
 
@@ -28,6 +28,7 @@ namespace ACulinaryArtillery
         {
             base.Initialize(api);
             RegisterGameTickListener(RotDrop, 3000);
+            Inventory.OnAcquireTransitionSpeed += Inventory_OnAcquireTransitionSpeed;
         }
 
         private void RotDrop(float dt)
@@ -71,15 +72,12 @@ namespace ACulinaryArtillery
             return false;
         }
 
-        protected override float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float baseMul)
+        private float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float baseMul)
         {
             if (Api == null) return 1;
-
             if (transType == EnumTransitionType.Cure) return Block.Attributes["cureRate"].AsFloat(3);
             if (transType == EnumTransitionType.Dry) return Block.Attributes["dryRate"].AsFloat(3);
-
-
-            return base.Inventory_OnAcquireTransitionSpeed(transType, stack, baseMul);
+            return baseMul;
 
         }
 
@@ -132,7 +130,7 @@ namespace ACulinaryArtillery
 
         public override void GetBlockInfo(IPlayer forPlayer, StringBuilder sb)
         {
-            base.GetBlockInfo(forPlayer, sb);
+            //base.GetBlockInfo(forPlayer, sb);
 
             sb.AppendLine();
 

--- a/Block Entity/BlockEntitySaucepan.cs
+++ b/Block Entity/BlockEntitySaucepan.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using ACulinaryArtillery.Block_Entity;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Vintagestory.API.Client;
@@ -15,11 +16,14 @@ namespace ACulinaryArtillery
         MeshData currentRightMesh;
         BlockSaucepan ownBlock;
         public bool isSealed;
-
+        public BlockEntitySaucepan()
+        {
+            container = new BESaucepanContainer(this,() => Inventory, "inventory");
+        }
         public override void Initialize(ICoreAPI api)
         {
             base.Initialize(api);
-
+            //Inventory.OnAcquireTransitionSpeed += Inventory_OnAcquireTransitionSpeed;
             ownBlock = Block as BlockSaucepan;
 
 
@@ -29,6 +33,16 @@ namespace ACulinaryArtillery
                 MarkDirty(true);
             }
         }
+
+        /*
+        private float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float mulByConfig)
+        {
+            float rate = container.GetPerishRate() * (isSealed ? Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
+            float mul = Inventory.GetTransitionSpeedMul(transType, stack);
+            return mul * rate;
+
+        }
+        */
 
         public override void OnBlockPlaced(ItemStack byItemStack = null)
         {
@@ -103,10 +117,11 @@ namespace ACulinaryArtillery
             }
         }
 
-
+        /*
         public override float GetPerishRate()
         {
             return base.GetPerishRate() * (isSealed ? Block.Attributes["lidPerishRate"].AsFloat(0.5f) : 1f);
         }
+        */
     }
 }

--- a/Block/BlockBottle.cs
+++ b/Block/BlockBottle.cs
@@ -782,7 +782,7 @@
         }
 
 
-        private int SplitStackAndPerformAction(Entity byEntity, ItemSlot slot, System.Func<ItemStack, int> action)
+        private new int SplitStackAndPerformAction(Entity byEntity, ItemSlot slot, System.Func<ItemStack, int> action)
         {
             if (slot.Itemstack.StackSize == 1)
             {

--- a/Item/ItemExpandedFood.cs
+++ b/Item/ItemExpandedFood.cs
@@ -7,6 +7,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.Server;
+using static HarmonyLib.Code;
 
 namespace ACulinaryArtillery
 {
@@ -29,6 +30,7 @@ namespace ACulinaryArtillery
 
                 foreach (FoodNutritionProperties prop in addProps)
                 {
+                    //ACulinaryArtillery.logger.Debug("Eated: " + prop.FoodCategory.ToString() + ": " + prop.Satiety.ToString());
                     byEntity.ReceiveSaturation(prop.Satiety * satLossMul, prop.FoodCategory);
 
                     float healthChange = prop.Health * healthLossMul;
@@ -63,6 +65,7 @@ namespace ACulinaryArtillery
                 {
                     float satLossMul = GlobalConstants.FoodSpoilageSatLossMul(spoilState, stack, entity);
                     float healthLossMul = GlobalConstants.FoodSpoilageHealthLossMul(spoilState, stack, entity);
+                    //ACulinaryArtillery.logger.Debug(props.FoodCategory.ToString() + ": " + props.Satiety.ToString());
     
                     if (stack.Collectible.MatterState == EnumMatterState.Liquid ) 
                     {

--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -14,7 +14,6 @@ using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 using Vintagestory.Common;
 using Vintagestory.GameContent;
-using VintagestoryAPI.Util;
 using static System.Formats.Asn1.AsnWriter;
 
 namespace ACulinaryArtillery
@@ -378,185 +377,7 @@ namespace ACulinaryArtillery
         public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
         {
             ListIngredients(inSlot, dsc, world, withDebugInfo);
-            ItemStack stack = inSlot.Itemstack;
-
-            string descLangCode = Code?.Domain + AssetLocation.LocationSeparator + ItemClass.ToString().ToLowerInvariant() + "desc-" + Code?.Path;
-            string descText = Lang.GetMatching(descLangCode);
-            if (descText == descLangCode)
-                descText = "";
-            else
-                descText = descText + "\n";
-
-            dsc.Append((withDebugInfo ? "Id: " + Id + "\n" : ""));
-            dsc.Append((withDebugInfo ? "Code: " + Code + "\n" : ""));
-
-            int durability = GetMaxDurability(stack);
-
-            if (durability > 1)
-            {
-                dsc.AppendLine(Lang.Get("Durability: {0} / {1}", stack.Attributes.GetInt("durability", durability), durability));
-            }
-
-
-            if (MiningSpeed != null && MiningSpeed.Count > 0)
-            {
-                dsc.AppendLine(Lang.Get("Tool Tier: {0}", ToolTier));
-
-                dsc.Append(Lang.Get("item-tooltip-miningspeed"));
-                int i = 0;
-                foreach (var val in MiningSpeed)
-                {
-                    if (val.Value < 1.1)
-                        continue;
-
-                    if (i > 0)
-                        dsc.Append(", ");
-                    dsc.Append(Lang.Get(val.Key.ToString()) + " " + val.Value.ToString("#.#") + "x");
-                    i++;
-                }
-
-                dsc.Append("\n");
-
-            }
-
-            if (IsBackPack(stack))
-            {
-                dsc.AppendLine(Lang.Get("Quantity Slots: {0}", QuantityBackPackSlots(stack)));
-                ITreeAttribute backPackTree = stack.Attributes.GetTreeAttribute("backpack");
-                if (backPackTree != null)
-                {
-                    bool didPrint = false;
-
-                    ITreeAttribute slotsTree = backPackTree.GetTreeAttribute("slots");
-
-                    foreach (var val in slotsTree)
-                    {
-                        ItemStack cstack = (ItemStack)val.Value?.GetValue();
-
-                        if (cstack != null && cstack.StackSize > 0)
-                        {
-                            if (!didPrint)
-                            {
-                                dsc.AppendLine(Lang.Get("Contents: "));
-                                didPrint = true;
-                            }
-                            cstack.ResolveBlockOrItem(world);
-                            dsc.AppendLine("- " + cstack.StackSize + "x " + cstack.GetName());
-                        }
-                    }
-
-                    if (!didPrint)
-                    {
-                        dsc.AppendLine(Lang.Get("Empty"));
-                    }
-
-                }
-            }
-
-            EntityPlayer entity = world.Side == EnumAppSide.Client ? (world as IClientWorldAccessor).Player.Entity : null;
-
-            float spoilState = AppendPerishableInfoText(inSlot, dsc, world);
-
-            FoodNutritionProperties nutriProps = GetNutritionProperties(world, stack, entity);
-            if (nutriProps != null)
-            {
-                float satLossMul = GlobalConstants.FoodSpoilageSatLossMul(spoilState, stack, entity);
-                float healthLossMul = GlobalConstants.FoodSpoilageHealthLossMul(spoilState, stack, entity);
-
-                if (Math.Abs(nutriProps.Health * healthLossMul) > 0.001f)
-                {
-                    dsc.AppendLine(Lang.Get("When eaten: {0} sat, {1} hp", Math.Round(nutriProps.Satiety * satLossMul), nutriProps.Health * healthLossMul));
-                }
-                else
-                {
-                    dsc.AppendLine(Lang.Get("When eaten: {0} sat", Math.Round(nutriProps.Satiety * satLossMul)));
-                }
-
-                dsc.AppendLine(Lang.Get("Food Category: {0}", Lang.Get("foodcategory-" + nutriProps.FoodCategory.ToString().ToLowerInvariant())));
-            }
-
-
-
-            if (GrindingProps != null)
-            {
-                dsc.AppendLine(Lang.Get("When ground: Turns into {0}x {1}", GrindingProps.GroundStack.ResolvedItemstack.StackSize, GrindingProps.GroundStack.ResolvedItemstack.GetName()));
-            }
-
-            if (CrushingProps != null)
-            {
-                dsc.AppendLine(Lang.Get("When pulverized: Turns into {0}x {1}", CrushingProps.CrushedStack.ResolvedItemstack.StackSize, CrushingProps.CrushedStack.ResolvedItemstack.GetName()));
-                dsc.AppendLine(Lang.Get("Requires Pulverizer tier: {0}", CrushingProps.HardnessTier));
-            }
-
-            if (GetAttackPower(stack) > 0.5f)
-            {
-                dsc.AppendLine(Lang.Get("Attack power: -{0} hp", GetAttackPower(stack).ToString("0.#")));
-                dsc.AppendLine(Lang.Get("Attack tier: {0}", ToolTier));
-            }
-
-            if (GetAttackRange(stack) > GlobalConstants.DefaultAttackRange)
-            {
-                dsc.AppendLine(Lang.Get("Attack range: {0} m", GetAttackRange(stack).ToString("0.#")));
-            }
-
-            if (CombustibleProps != null)
-            {
-                if (CombustibleProps.BurnTemperature > 0)
-                {
-                    dsc.AppendLine(Lang.Get("Burn temperature: {0}°C", CombustibleProps.BurnTemperature));
-                    dsc.AppendLine(Lang.Get("Burn duration: {0}s", CombustibleProps.BurnDuration));
-                }
-
-
-                string smelttype = CombustibleProps.SmeltingType.ToString().ToLowerInvariant();
-                if (CombustibleProps.MeltingPoint > 0)
-                {
-                    dsc.AppendLine(Lang.Get("game:smeltpoint-" + smelttype, CombustibleProps.MeltingPoint));
-                }
-
-                if (CombustibleProps.SmeltedStack?.ResolvedItemstack != null)
-                {
-                    int instacksize = CombustibleProps.SmeltedRatio;
-                    int outstacksize = CombustibleProps.SmeltedStack.ResolvedItemstack.StackSize;
-
-
-                    string str = instacksize == 1 ?
-                        Lang.Get("game:smeltdesc-" + smelttype + "-singular", outstacksize, CombustibleProps.SmeltedStack.ResolvedItemstack.GetName()) :
-                        Lang.Get("game:smeltdesc-" + smelttype + "-plural", instacksize, outstacksize, CombustibleProps.SmeltedStack.ResolvedItemstack.GetName())
-                    ;
-
-                    dsc.AppendLine(str);
-                }
-            }
-
-            if (descText.Length > 0 && dsc.Length > 0)
-                dsc.Append("\n");
-            dsc.Append(descText);
-
-            if (Attributes?["pigment"]?["color"].Exists == true)
-            {
-                dsc.AppendLine(Lang.Get("Pigment: {0}", Lang.Get(Attributes["pigment"]["name"].AsString())));
-            }
-
-
-            JsonObject obj = Attributes?["fertilizerProps"];
-            if (obj != null && obj.Exists)
-            {
-                FertilizerProps props = obj.AsObject<FertilizerProps>();
-                if (props != null)
-                {
-                    dsc.AppendLine(Lang.Get("Fertilizer: {0}% N, {1}% P, {2}% K", props.N, props.P, props.K));
-                }
-            }
-
-
-
-
-            float temp = GetTemperature(world, stack);
-            if (temp > 20)
-            {
-                dsc.AppendLine(Lang.Get("Temperature: {0}°C", (int)temp));
-            }
+            base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
         }
 
         public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
@@ -652,10 +473,10 @@ namespace ACulinaryArtillery
             // Render first added ingredient before everything else to avoid transparent bread
             AssetLocation baseIngredient = addShapes.Last();
             Dictionary<String, String> baseMapping = texureMappingsPerShape.Last();
-            texureMappingsPerShape.Remove(baseMapping);
-            texureMappingsPerShape.Insert(0, baseMapping);
-            addShapes.Remove(baseIngredient);
-            addShapes.Insert(0, baseIngredient);
+            //texureMappingsPerShape.Remove(baseMapping);
+            //texureMappingsPerShape.Insert(0, baseMapping);
+            //addShapes.Remove(baseIngredient);
+            //addShapes.Insert(0, baseIngredient);
 
             MeshData mesh = null;
             float uvoffset = 0;
@@ -670,6 +491,7 @@ namespace ACulinaryArtillery
 
                 var keys = (addShape.Textures?.Keys);
                 Shape clonedAddShape = addShape.Clone();
+                clonedAddShape.Textures = new Dictionary<string, AssetLocation>(addShape.Textures);
                 //clonedAddShape.Textures.Clear();
                 if (keys is not null && texureMappingsPerShape[i].Count() > 0)
                 {
@@ -700,14 +522,14 @@ namespace ACulinaryArtillery
                             {
                                 if(face != null)
                                 {
-                                float faceWidth = Math.Abs(face.Uv[2] - face.Uv[0]);
-                                float faceHeight = Math.Abs(face.Uv[3] - face.Uv[1]);
-                                float ustart = (float)Math.Floor(uvoffset * (texWidth - faceWidth));
-                                float vstart = (float)Math.Floor(uvoffset * (texHeight - faceHeight));
-                                face.Uv[0] = ustart;
-                                face.Uv[1] = vstart;
-                                face.Uv[2] = ustart + faceWidth;
-                                face.Uv[3] = vstart + faceHeight;
+                                    float faceWidth = Math.Abs(face.Uv[2] - face.Uv[0]);
+                                    float faceHeight = Math.Abs(face.Uv[3] - face.Uv[1]);
+                                    float ustart = (float)Math.Floor(uvoffset * (texWidth - faceWidth));
+                                    float vstart = (float)Math.Floor(uvoffset * (texHeight - faceHeight));
+                                    face.Uv[0] = ustart;
+                                    face.Uv[1] = vstart;
+                                    face.Uv[2] = ustart + faceWidth;
+                                    face.Uv[3] = vstart + faceHeight;
                                 }
                             }
                         }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Client": {
       "commandName": "Executable",
       "executablePath": "dotnet",
-      "commandLineArgs": "\"$(VINTAGE_STORY)/Vintagestory.dll\" -oTestWorld -pcreativebuilding --tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
+      "commandLineArgs": "\"$(VINTAGE_STORY)/Vintagestory.dll\" --tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
       "workingDirectory": "$(VINTAGE_STORY)"
     },
     "Server": {

--- a/assets/aculinaryartillery/itemtypes/wearable/chefhead.json
+++ b/assets/aculinaryartillery/itemtypes/wearable/chefhead.json
@@ -15,7 +15,13 @@
 		"@.*-(c-hat|c-hat1|c-hat2)": {
 			wearableAttachment: true,
 			clothescategory: "head",
-			disableElements: ["Ponytail1"]
+			disableElements: ["Ponytail1"],
+			attachableToEntity: {
+				"categoryCode": "bridle"
+			},
+			"attachedShapeBySlotCode": {
+				"*-head": {"base":  "entity/humanoid/serpah/clothing/head/{head}"}
+			}
 		}
 	},
 	texturesByType: {

--- a/assets/aculinaryartillery/patches/trader-clothing.json
+++ b/assets/aculinaryartillery/patches/trader-clothing.json
@@ -1,7 +1,7 @@
 ﻿[
   {
     "op": "addeach",
-    "path": "/attributes/tradeProps/selling/list/-",
+    "path": "/selling/list/-",
     "value": [
     {
       "code": "aculinaryartillery:clothes-head-c-hat",
@@ -43,6 +43,6 @@
       }
     },
     ],
-    "file": "game:entities/humanoid/trader-clothing.json"
+    "file": "game:config/tradelists/trader-clothing.json"
   },
 ]

--- a/assets/aculinaryartillery/recipes/clayforming/bighookmold.json
+++ b/assets/aculinaryartillery/recipes/clayforming/bighookmold.json
@@ -1,5 +1,5 @@
 {
-	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire"] },
+	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire", "red"] },
 	pattern: [[
 		"##############",
 		"##############",

--- a/assets/aculinaryartillery/recipes/clayforming/bottle.json
+++ b/assets/aculinaryartillery/recipes/clayforming/bottle.json
@@ -1,5 +1,5 @@
 {
-	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire"] },
+	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire", "red"] },
 	pattern: [[
 		"###",
 		"###",

--- a/assets/aculinaryartillery/recipes/clayforming/bottle4.json
+++ b/assets/aculinaryartillery/recipes/clayforming/bottle4.json
@@ -1,5 +1,5 @@
 {
-	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire"] },
+	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire", "red"] },
 	pattern: [[
 		"###_###_",
 		"###_###_",

--- a/assets/aculinaryartillery/recipes/clayforming/cauldronminimold.json
+++ b/assets/aculinaryartillery/recipes/clayforming/cauldronminimold.json
@@ -3,7 +3,7 @@
     "type": "item",
     "code": "game:clay-*",
     "name": "type",
-    "allowedVariants": ["blue", "fire"]
+    "allowedVariants": ["blue", "fire", "red"]
   },
     "pattern": [
         [

--- a/assets/aculinaryartillery/recipes/clayforming/cauldronmold.json
+++ b/assets/aculinaryartillery/recipes/clayforming/cauldronmold.json
@@ -3,7 +3,7 @@
     "type": "item",
     "code": "game:clay-*",
     "name": "type",
-    "allowedVariants": ["blue", "fire"]
+    "allowedVariants": ["blue", "fire", "red"]
   },
     "pattern": [
         [

--- a/assets/aculinaryartillery/recipes/clayforming/saucepan.json
+++ b/assets/aculinaryartillery/recipes/clayforming/saucepan.json
@@ -1,5 +1,5 @@
 {
-	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire"] },
+	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire", "red"] },
 	pattern: [
 		[
 			"____________",

--- a/assets/aculinaryartillery/recipes/clayforming/spile.json
+++ b/assets/aculinaryartillery/recipes/clayforming/spile.json
@@ -1,5 +1,5 @@
 ﻿{
-	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire"] },
+	ingredient: { type: "item", code: "game:clay-*", name: "type", allowedVariants: ["blue", "fire", "red"] },
 	pattern: [[
 		"################",
 		"################",


### PR DESCRIPTION
-Migrated transition and perish methods into their new event equivalencies 
-Minor refactor to use new InWorldContainer
^Thanks to Bosek for the initial work on these two documented in his PR, was a good base to learn the new changes and implement.
-Bug fix for textureMap per ingredient shape causing shapes to render with missing textures under certain ingredient combinations
-Added support for Chef Hat on tamed Elk
-Removed some extraneous code from GetHeldInfo for ItemExpandedRawFood as it shouldve just called its base instead 
-Other misc changes ive forgotten already