### PR TITLE
Add support for configurable item stack sizes to Mixing Bowl

### DIFF
--- a/Block Entity/BEMixingBowl.cs
+++ b/Block Entity/BEMixingBowl.cs
@@ -56,6 +56,8 @@ namespace ACulinaryArtillery
         public float inputMixTime;
         public float prevInputMixTime;
         public int CapacityLitres { get; set; }
+        public int MaxContainerSlotStackSize { get; set; }
+        public const int DefaultMaxContainerSlotStackSize = 6;
 
         //For automation
         public bool invLocked;
@@ -150,9 +152,7 @@ namespace ACulinaryArtillery
             inventory = new InventoryMixingBowl(null, null, this);
             inventory.SlotModified += OnSlotModifid;
         }
-
-
-
+        
         public override void Initialize(ICoreAPI api)
         {
             base.Initialize(api);
@@ -166,7 +166,16 @@ namespace ACulinaryArtillery
             {
                 CapacityLitres = Block.Attributes["capacityLitres"].AsInt(CapacityLitres);
             }
-
+            if (Block.Attributes["maxContainerSlotStackSize"].Exists == true)
+            {
+                MaxContainerSlotStackSize = Block.Attributes["maxContainerSlotStackSize"].AsInt(DefaultMaxContainerSlotStackSize);
+            }
+            else
+            {
+                // This is the default if no maxContainerSlotStackSize is specified.
+                // Needed for backwards compatibility.
+                MaxContainerSlotStackSize = DefaultMaxContainerSlotStackSize;
+            }
             if (ambientSound == null && api.Side == EnumAppSide.Client)
             {
                 ambientSound = ((IClientWorldAccessor)api.World).LoadSound(new SoundParams()

--- a/Inventory/InventoryMixingBowl.cs
+++ b/Inventory/InventoryMixingBowl.cs
@@ -28,7 +28,6 @@ namespace ACulinaryArtillery
             //slots 2-7 = ingredients
             machine = bowl;
             slots = GenEmptySlots(8);
-
         }
 
 
@@ -61,8 +60,8 @@ namespace ACulinaryArtillery
             {
                 for (int i = 2; i < this.Count; i++)
                 {
-                    this[i].MaxSlotStackSize = 6;
-                    (this[i] as ItemSlotMixingBowl).Set(machine, i - 2);
+                    this[i].MaxSlotStackSize = machine.MaxContainerSlotStackSize;
+                    (this[i] as ItemSlotMixingBowl)?.Set(machine, i - 2);
                 }
             }
         }
@@ -109,10 +108,9 @@ namespace ACulinaryArtillery
     {
         BlockEntityMixingBowl machine;
         int stackNum;
-
+        
         public ItemSlotMixingBowl(InventoryBase inventory, BlockEntityMixingBowl bowl, int itemNumber) : base(inventory)
         {
-            MaxSlotStackSize = 6;
             machine = bowl;
             stackNum = itemNumber;
         }
@@ -120,6 +118,14 @@ namespace ACulinaryArtillery
         public override bool CanTakeFrom(ItemSlot sourceSlot, EnumMergePriority priority = EnumMergePriority.AutoMerge)
         {
             return base.CanTakeFrom(sourceSlot, priority) && locked(sourceSlot);
+        }
+        
+        public override int MaxSlotStackSize
+        {
+            get
+            {
+                return machine.MaxContainerSlotStackSize;
+            }
         }
 
         public override bool CanHold(ItemSlot sourceSlot)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# A Culinary Artillery: Vinterra Fork
+
+Ways in which this diverges from mainline:
+- Configurable stack sizes for mixing bowl.


### PR DESCRIPTION
Hey! Small unsolicited change here from the [Vinterra](https://www.vinterra.org/) server 😄 Some of our members *really* like making bread and asked if this stack size could be made configurable to be in better proportion with the liquid capacity for those recipes.

I did my best to follow the existing structure and tested with both configured stack sizes and no specified value to make sure it'd be backwards compatible. Lemme know if you need any changes here and thanks for writing such a cool mod! 🙏 