### PR TITLE
fix: averaging nutrition values when bulk simmering

### DIFF
--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -65,12 +65,12 @@ namespace ACulinaryArtillery
                 MouseButton = EnumMouseButton.Right,
                 Itemstacks = liquidContainerStacks
             }, new () {
-                ActionLangCode = "aculinaryartillery:blockhelp-open", // json lang file. 
+                ActionLangCode = "aculinaryartillery:blockhelp-open", // json lang file.
                 HotKeyCodes = ["shift", "ctrl"],
                 MouseButton = EnumMouseButton.Right,
                 ShouldApply = (wi, bs, es) => GetBlockEntity<BlockEntitySaucepan>(bs.Position)?.isSealed == true
             }, new () {
-                ActionLangCode = "aculinaryartillery:blockhelp-close", // json lang file. 
+                ActionLangCode = "aculinaryartillery:blockhelp-close", // json lang file.
                 HotKeyCodes = ["shift", "ctrl"],
                 MouseButton = EnumMouseButton.Right,
                 ShouldApply = (wi, bs, es) => GetBlockEntity<BlockEntitySaucepan>(bs.Position)?.isSealed == false
@@ -85,7 +85,7 @@ namespace ACulinaryArtillery
             //the cookingSlots are not necessarily filled in order. We just want the ones that are.
             List<ItemStack> stacks = [.. cookingSlotsProvider.Slots.Where(slot => !slot.Empty).Select(slot => slot.Itemstack.Clone())];
 
-            //if it's just one stack, no need for an actual recipe, but we need to check the CombustibleProps 
+            //if it's just one stack, no need for an actual recipe, but we need to check the CombustibleProps
             if (stacks.Count == 1)
             {
                 var combustProps = stacks[0].Collectible?.CombustibleProps;
@@ -115,8 +115,8 @@ namespace ACulinaryArtillery
             else if (contents.Count > 1)
             {
                 if (api.GetSimmerRecipes().FirstOrDefault(rec => rec.Match(contents) > 0) is not SimmerRecipe match) return; // Make sure a recipe matches
-                int amountForTheseIngredients = match.Match(contents); 
-                
+                int amountForTheseIngredients = match.Match(contents);
+
                 match.Simmering.SmeltedStack.Resolve(world, "Saucepansimmerrecipesmeltstack");
                 product = match.Simmering.SmeltedStack.ResolvedItemstack.Clone();
 
@@ -143,7 +143,7 @@ namespace ACulinaryArtillery
                         }
                     }
 
-                    prodObj.OnCreatedByKneading(input, product);
+                    prodObj.OnCreatedBySimmering(input, product);
                 }
             }
 

--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -123,6 +123,41 @@ namespace ACulinaryArtillery
             output.Attributes["expandedSats"] = new FloatArrayAttribute([.. sat]);
         }
 
+        public void OnCreatedBySimmering(Dictionary<ItemSlot, CraftingRecipeIngredient> input, ItemStack output)
+        {
+            HashSet<string> ingredients = [];
+            float[] sat = new float[6];
+
+            foreach (var val in input)
+            {
+                var stack = val.Key.Itemstack;
+                var collObj = stack.Collectible;
+                var collObjId = $"{collObj.Code.Domain}:{collObj.Code.Path}";
+                if (collObj is ItemExpandedRawFood)
+                {
+                    string[]? addIngs = (stack.Attributes["madeWith"] as StringArrayAttribute)?.value;
+                    float[]? addSat = (stack.Attributes["expandedSats"] as FloatArrayAttribute)?.value;
+
+                    if (addSat?.Length == 6) sat = [.. sat.Zip(addSat, (x, y) => x + (y * (val.Value.Quantity / (collObj is ItemExpandedLiquid ? 10 : 1))))];
+                    if (addIngs?.Length > 0) ingredients.AddRange(addIngs);
+                }
+                else
+                {
+                    float[] addSat = new float[6];
+                    GetNutrientsFromIngredient(ref addSat, collObj, val.Value.Quantity);
+                    // If no nutrition is added then we should skip adding it to the 'madeWith' attribute
+                    // so outputs with otherwise identical 'nutritional' ingredients will stack together.
+                    if (addSat.Any((x) => x > 0.0f)) {
+                      sat = [.. sat.Zip(addSat, (x, y) => x + y)];
+                      ingredients.Add(collObjId);
+                    }
+                }
+            }
+
+            output.Attributes["madeWith"] = new StringArrayAttribute([.. ingredients.Order()]);
+            output.Attributes["expandedSats"] = new FloatArrayAttribute([.. sat]);
+        }
+
         public override bool CanSmelt(IWorldAccessor world, ISlotProvider cookingSlotsProvider, ItemStack inputStack, ItemStack outputStack)
         {
             if (inputStack.Collectible.CombustibleProps == null) return false;
@@ -531,6 +566,7 @@ namespace ACulinaryArtillery
     public interface IExpandedFood
     {
         void OnCreatedByKneading(Dictionary<ItemSlot, CraftingRecipeIngredient> input, ItemStack output);
+        void OnCreatedBySimmering(Dictionary<ItemSlot, CraftingRecipeIngredient> input, ItemStack output);
         void OnCreatedByGrinding(ItemStack input, ItemStack output);
     }
 


### PR DESCRIPTION
this changes the simmering to use it's own "OnCreatedBySimmering" method instead of the previously used "OnCreatedByKneading". the Simmering method body matches the Kneading method, except it excludes the logic to divide the nutritional values of the output by the input's stack size.

Additionally I included my fix for "filtering inedible ingredients" from #87 in the new method.