### PR TITLE
Fixes the expanded nutrition props splitting when simmering multiple items

### DIFF
--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -106,7 +106,7 @@ namespace ACulinaryArtillery
                     string[]? addIngs = (stack.Attributes["madeWith"] as StringArrayAttribute)?.value;
                     float[]? addSat = (stack.Attributes["expandedSats"] as FloatArrayAttribute)?.value;
 
-                    if (addSat?.Length == 6) sat = [.. sat.Zip(addSat, (x, y) => x + (y * (val.Value.Quantity / (stack.Collectible is ItemExpandedLiquid ? 10 : 1))))];
+                    if (addSat?.Length == 6) sat = [.. sat.Zip(addSat, (x, y) => x + (y * (stack.StackSize / (stack.Collectible is ItemExpandedLiquid ? 10 : 1))))];
                     if (addIngs?.Length > 0) ingredients.AddRange(addIngs);
                 }
                 else


### PR DESCRIPTION
This should fix the nutritions splitting when simmering more than one item by changing the way the expanded nutrition is calculated by pulling actual quantities used in the craft rather than the quantities the recipe itself defines