### PR TITLE
fix raw food "vanishing" when smelting/cooking on a firepit

### DIFF
--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -201,7 +201,7 @@ namespace ACulinaryArtillery
             outputSlot.Itemstack?.Collectible.TryMergeStacks(new(world, EnumMouseButton.Left, 0, EnumMergePriority.ConfirmedMerge, smeltedStack.StackSize)
             {
                 SourceSlot = new DummySlot(smeltedStack),
-                SinkSlot = outputSlot
+                SinkSlot = new DummySlot(outputSlot.Itemstack)
             });
             outputSlot.Itemstack ??= smeltedStack; // Otherwise put the smelted stack into the output slot
 


### PR DESCRIPTION
fixes a bug where raw food disappears when cooking in a firepit instead of getting added to the output stack

repro steps:
1. Create e.g. multiple sausages with the mixing bowl
2. Add the raw food to the firepit to cook
3. the first item cooks fine, following items will just vanish after the progress bar is finished 