### PR TITLE
Round the number of liters in the firepit UI instead of truncating it.

### DIFF
--- a/Block/BlockSaucepan.cs
+++ b/Block/BlockSaucepan.cs
@@ -294,9 +294,9 @@ namespace ACulinaryArtillery
 
             if (GetContainableProps(product) is WaterTightContainableProps props)
             {
-                float litres = amount * (product.StackSize / props.ItemsPerLitre);
+                float millilitres = (float) Math.Round((float)amount * product.StackSize * 1000 / props.ItemsPerLitre);
 
-                return Lang.Get("mealcreation-nonfood-liquid", litres < 0.1 ? Lang.Get("{0} mL", (int)(litres * 1000)) : Lang.Get("{0:0.##} L", litres), product.GetName());
+                return Lang.Get("mealcreation-nonfood-liquid", millilitres < 100 ? Lang.Get("{0} mL", millilitres) : Lang.Get("{0:0.##} L", millilitres / 1000), product.GetName());
             }
 
             return Lang.Get("firepit-gui-willcreate", amount, product.GetName());


### PR DESCRIPTION
Floating-point error from not-precisely representable values like 1/100 (1 portion / 100 portions per liter) results in e.g. 200mL of sap -> 49.9999999 mL of syrup, which truncates to 49mL in the UI.

# Before
<img width="133" height="184" alt="Screenshot 2026-07-19 000953" src="https://github.com/user-attachments/assets/c9a28a01-45e2-4bc3-a028-463e45d1cdc8" />

# After
<img width="132" height="182" alt="Screenshot 2026-07-19 001159" src="https://github.com/user-attachments/assets/725bc422-51d7-42dd-a390-79c1c7c09ea8" />
