### PR TITLE
Change mixing bowl to skip cycles when output sides are blocked instead of discarding ingredients.

### DIFF
--- a/Block Entity/BlockEntityMixingBowl.cs
+++ b/Block Entity/BlockEntityMixingBowl.cs
@@ -200,7 +200,10 @@ namespace ACulinaryArtillery
 
             ItemStack? mixedStack = null;
             int servings = 0;
-            ItemStack[] stacks = IngredStacks;
+            // Clone, don't alias: IngredStacks hands back the live inventory stacks, and the meal path
+            // below mutates them. We may still bail out before consuming anything, so that work has to
+            // happen on copies for now.
+            ItemStack[] stacks = [.. IngredStacks.Select(stack => stack.Clone())];
             if (mrecipe != null)
             {
                 string? mealBlockCode = InputStack.ItemAttributes?["mealBlockCode"].AsString();
@@ -229,23 +232,15 @@ namespace ACulinaryArtillery
                 }
 
                 ((BlockCookedContainer)mealBlock).SetContents(mrecipe.Code, servings, mixedStack, stacks);
-
-                inventory[0].TakeOut(1);
-                inventory[0].MarkDirty();
-                for (var i = 0; i < IngredSlots.Length; i++)
-                {
-                    //the recipe must be valid at this point, so can't we just take out everything? Like so
-                    if (IngredSlots[i].Itemstack != null)
-                    {
-                        IngredSlots[i].TakeOut(IngredSlots[i].Itemstack.StackSize);
-                        IngredSlots[i].MarkDirty();
-                    }
-                }
             }
-            else if (drecipe != null) mixedStack = drecipe.TryCraftNow(Api, IngredSlots);
+            else if (drecipe != null) mixedStack = drecipe.TryGetOutput(IngredSlots);
 
             if (mixedStack == null) return;
 
+            // Work out where the result goes BEFORE consuming anything. Everything above only built
+            // the output stack; the ingredients are still untouched at this point, so bailing out here
+            // costs nothing but the mixing cycle. This mirrors the vanilla quern: if the output slot is
+            // full and the side we'd eject onto is blocked, the cycle is wasted rather than the food.
             if (OutputSlot.Itemstack == null) OutputSlot.Itemstack = mixedStack;
             else
             {
@@ -258,10 +253,27 @@ namespace ACulinaryArtillery
                     nowOutputFace = (nowOutputFace + 1) % 4;
 
                     Block block = Api.World.BlockAccessor.GetBlock(Pos.AddCopy(face));
-                    if (block.Replaceable < 6000) return;
+                    if (block.Replaceable < 6000) return; // Blocked side: keep the ingredients, waste the cycle
                     Api.World.SpawnItemEntity(mixedStack, Pos.ToVec3d().Add(0.5 + face.Normalf.X * 0.7, 0.75, 0.5 + face.Normalf.Z * 0.7), new Vec3d(face.Normalf.X * 0.02f, 0, face.Normalf.Z * 0.02f));
                 }
             }
+
+            // The output is committed, so it's safe to consume the ingredients
+            if (mrecipe != null)
+            {
+                inventory[0].TakeOut(1);
+                inventory[0].MarkDirty();
+                for (var i = 0; i < IngredSlots.Length; i++)
+                {
+                    //the recipe must be valid at this point, so can't we just take out everything? Like so
+                    if (IngredSlots[i].Itemstack != null)
+                    {
+                        IngredSlots[i].TakeOut(IngredSlots[i].Itemstack.StackSize);
+                        IngredSlots[i].MarkDirty();
+                    }
+                }
+            }
+            else drecipe!.ConsumeIngredients(IngredSlots, mixedStack);
 
             OutputSlot.MarkDirty();
         }

--- a/Util/RecipeSystem.cs
+++ b/Util/RecipeSystem.cs
@@ -332,6 +332,20 @@ namespace ACulinaryArtillery
 
         public ItemStack? TryCraftNow(ICoreAPI api, ItemSlot[] inputslots)
         {
+            ItemStack? mixedStack = TryGetOutput(inputslots);
+            if (mixedStack == null) return null;
+
+            ConsumeIngredients(inputslots, mixedStack);
+
+            return mixedStack;
+        }
+
+        /// <summary>
+        /// Builds what this recipe would produce from the given input WITHOUT consuming anything, so a
+        /// caller can check it has somewhere to put the result before committing to the craft.
+        /// </summary>
+        public ItemStack? TryGetOutput(ItemSlot[] inputslots)
+        {
             var matched = pairInput(inputslots);
             if (matched == null) return null;
             
@@ -342,13 +356,23 @@ namespace ACulinaryArtillery
 
             if (mixedStack.Collectible is IExpandedFood food) food.OnCreatedByKneading(matched, mixedStack);
 
+            return mixedStack;
+        }
+
+        /// <summary>
+        /// Consumes the ingredients for a craft that has already been committed. <paramref name="craftedStack"/>
+        /// must be the stack returned by <see cref="TryGetOutput"/>, so the amounts taken match its size.
+        /// </summary>
+        public void ConsumeIngredients(ItemSlot[] inputslots, ItemStack craftedStack)
+        {
+            var matched = pairInput(inputslots);
+            if (matched == null) return;
+
             foreach (var val in matched)
             {
-                val.Key.TakeOut(val.Value.Quantity * (mixedStack.StackSize / Output.StackSize));
+                val.Key.TakeOut(val.Value.Quantity * (craftedStack.StackSize / Output.StackSize));
                 val.Key.MarkDirty();
             }
-            
-            return mixedStack;
         }
 
         public bool Matches(IWorldAccessor worldForResolve, ItemSlot[] inputSlots)


### PR DESCRIPTION
Prior to this change, if some sides of the mixing bowl were blocked and there wasn't space in the mixing bowl output, items would sometimes disappear into thin air. This commit changes the behavior to match the quern: when the next output side is blocked, make the cycle a no-op instead of consuming ingredients, slowing down the progress rate (and stopping it entirely if all four sides are blocked).

We do this by splitting the calculation in two:
(A) figure out what is being produced, what updates to make to the ingredient stacks, and most importantly, where the output will go, and then (B) if and only if the output can be placed somewhere, consume ingredients. Otherwise, no-op this production cycle.

# Demo of new behavior
(it might be kind of hard to notice but now the output is flying out the unblocked side every 4th cycle (and then getting caught by my seraph))

https://github.com/user-attachments/assets/5a8fab82-2e81-4f4b-978b-e7afcce28ec9

