### PR TITLE
Fix crash when GetExpandedContentNutritionProperties found combustibleProps but had no SmeltedStack

### DIFF
--- a/Item/ItemExpandedRawFood.cs
+++ b/Item/ItemExpandedRawFood.cs
@@ -484,7 +484,7 @@ namespace ACulinaryArtillery
             FoodNutritionProperties? nutriProps;
 
             nutriProps = obj.Attributes?["nutritionPropsWhenInMeal"].AsObject<FoodNutritionProperties>();
-            nutriProps ??= cprops?.SmeltedStack.ResolvedItemstack?.Collectible.GetNutritionProperties(world, cprops.SmeltedStack.ResolvedItemstack, forEntity);
+            nutriProps ??= cprops?.SmeltedStack?.ResolvedItemstack?.Collectible.GetNutritionProperties(world, cprops.SmeltedStack.ResolvedItemstack, forEntity);
             nutriProps ??= liquidProps?.NutritionPropsPerLitreWhenInMeal;
 
             if (liquidProps != null && nutriProps == null)


### PR DESCRIPTION
Caused a crash when trying to place an empty cooking pot into a firepit which had a cooking pot filled with rotten food in the output slot.