### PR TITLE
Fix spile placement issues and improve error messages

### DIFF
--- a/Block/BlockSpile.cs
+++ b/Block/BlockSpile.cs
@@ -5,28 +5,36 @@ namespace ACulinaryArtillery
 {
     public class BlockSpile : Block
     {
-        public override bool CanPlaceBlock(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ref string failureCode)
+        // Using CanPlaceBlock causes the error message to be overriden by BlockBehaviorHorizontalAttachable
+        public override bool TryPlaceBlock(IWorldAccessor world, IPlayer byPlayer, ItemStack itemstack, BlockSelection blockSel, ref string failureCode)
         {
-            if (blockSel.Face.IsHorizontal && hasSpile(world.BlockAccessor, blockSel.Position.Copy(), blockSel.Face))
+            Block? attachingTo = world.BlockAccessor.GetBlock(blockSel.Position.AddCopy(blockSel.Face, -1));
+            if (blockSel.Face.IsHorizontal && attachingTo?.Attributes?["sapProperties"]?.AsObject<SapProperties>() == null)
+            {
+                failureCode = "notspileable";
+                return false;
+            }
+
+            if (blockSel.Face.IsHorizontal && HasSpile(world.BlockAccessor, blockSel.Position.Copy(), blockSel.Face))
             {
                 failureCode = "alreadyhasspile";
                 return false;
             }
 
-            return base.CanPlaceBlock(world, byPlayer, blockSel, ref failureCode);
+            return base.TryPlaceBlock(world, byPlayer, itemstack, blockSel, ref failureCode);
         }
 
-        bool hasSpile(IBlockAccessor blockAccess, BlockPos pos, BlockFacing face)
+        bool HasSpile(IBlockAccessor blockAccess, BlockPos pos, BlockFacing face)
         {
-            pos.Add(face, 2); // check the opposite side of the log
+            pos.Add(face, -2); // check the opposite side of the log
             if (blockAccess.GetBlock(pos) is BlockSpile) return true;
 
-            pos.Add(face, -1); // move back into the log
+            pos.Add(face, 1); // move back into the log
             face = face.GetCW(); // turn 90° clockwise
-            pos.Add(face); // move to the next side
+            pos.Add(face, -1); // move to the next side
             if (blockAccess.GetBlock(pos) is BlockSpile) return true;
 
-            pos.Add(face, -2); // and finally move back through the log to the third side
+            pos.Add(face, 2); // and finally move back through the log to the third side
             if (blockAccess.GetBlock(pos) is BlockSpile) return true;
 
             return false;

--- a/assets/aculinaryartillery/lang/en.json
+++ b/assets/aculinaryartillery/lang/en.json
@@ -43,6 +43,8 @@
   "block-spile-titanium-*" : "Titanium spile",
   "block-spile-steel-*": "Steel spile",
   "blockdesc-spile-*": "Gently siphon the liquid nectar from the trees around you.",
+  "game:placefailure-alreadyhasspile": "This block already has a spile.",
+  "game:placefailure-notspileable": "This block cannot be tapped.",
   "block-handbooktitle-spile": "Metal Spile",
   "block-handbooktext-spile": "A metal peg that broaches liquid from various trees. Whether or not a tree produces liquid depends on the time of year, as trees produce more or less sap, gum, or nectar during certain seasons. Tapping a tree creates a small wound in the bark that allows sap to flow like blood, albeit slowly.",
   


### PR DESCRIPTION
* Checks for other spiles on the block were inverted.
* `BlockBehaviorHorizontalOrientable` requires use of `TryPlaceBlock` instead of `CanPlaceBlock` for custom error codes.
* Added a separate error code to prevent placement on blocks that can't be spiled by checking `sapProperties`.

<img width="2560" height="1368" alt="2026-07-31_16-31-18" src="https://github.com/user-attachments/assets/ac463e9c-d900-42e0-a811-7a09dbf114db" />
<img width="2560" height="1368" alt="2026-07-31_16-31-23" src="https://github.com/user-attachments/assets/8b96c968-a024-4f99-beb6-d28a01682f19" />

*(Log broken and replaced)*
<img width="2560" height="1368" alt="2026-07-31_16-31-32" src="https://github.com/user-attachments/assets/99f716d9-74d7-45cb-af77-b34d83462485" />
