### PR TITLE
Add missing newline before CreatedBy additions

### DIFF
--- a/Util/HandbookInfoExtensions.cs
+++ b/Util/HandbookInfoExtensions.cs
@@ -19,7 +19,7 @@ namespace ACulinaryArtillery.Util
             ItemStack[] resolvedStacks = [.. capi.GetKneadingRecipes().Where(rec => rec.Ingredients.Any(ing => ing.GetMatch(maxstack) != null)).Select(rec => rec.Output.ResolvedItemStack),
                                           .. capi.GetSimmerRecipes().Where(rec => rec.Ingredients.Any(ing => ing.SatisfiesAsIngredient(maxstack))).Select(rec => rec.Simmering.SmeltedStack.ResolvedItemStack)];
 
-            List<ItemStack> recipestacks = [..allStacks.Where(stack => resolvedStacks.Where(rstack => rstack != null).Any(rstack => stack.Equals(capi.World, rstack, GlobalConstants.IgnoredStackAttributes)))];
+            List<ItemStack> recipestacks = [.. allStacks.Where(stack => resolvedStacks.Where(rstack => rstack != null).Any(rstack => stack.Equals(capi.World, rstack, GlobalConstants.IgnoredStackAttributes)))];
             List<CookingRecipe> mixingrecipes = [.. capi.GetMixingRecipes().Where(recipe => recipe.CooksInto?.ResolvedItemStack == null && recipe.Ingredients!.Any(ingred => ingred.GetMatchingStack(stack) != null))];
 
             if (recipestacks.Count == 0 && mixingrecipes.Count == 0) return [];
@@ -96,6 +96,7 @@ namespace ACulinaryArtillery.Util
 
             List<RichTextComponentBase> components = [];
             var verticalSpace = new ClearFloatTextComponent(capi, 7);
+            components.Add(verticalSpace);
 
             if (kneadingRecipes.Length > 0)
             {

--- a/assets/aculinaryartillery/lang/en.json
+++ b/assets/aculinaryartillery/lang/en.json
@@ -326,7 +326,7 @@
   "aculinaryartillery:smeltdesc-simmer-title": "Simmers into",
 
   "aculinaryartillery:handbook-createdby-mixingbowl": "Kneading",
-  "aculinaryartillery:handbook-createdby-simmering": "Simmering",
+  "aculinaryartillery:handbook-createdby-simmering": "Simmering (in saucepan or cauldron)",
   
   "aculinaryartillery:Will make {0}" : "Will make {0}",
   "aculinaryartillery:made with " : "made with ",


### PR DESCRIPTION
There was no newline at the beginning of the CreatedBy additions, so if there were vanilla CreatedBy entries like baking, the first addition would appear on the same line. Also added `(in saucepan or cauldron)` to the text.


<img width="774" height="904" alt="image" src="https://github.com/user-attachments/assets/97538be8-d258-4cb4-b0f5-286631f7d12f" />
