### PR TITLE
Replace custom tryEatStop override with standard usage of DrinkPortionSize

### DIFF
--- a/Block/BlockBottle.cs
+++ b/Block/BlockBottle.cs
@@ -43,6 +43,7 @@ namespace ACulinaryArtillery
         {
             base.OnLoaded(api);
             props = Attributes?["liquidContainerProps"]?.AsObject(props, Code.Domain) ?? props;
+            drinkPortionSizeFromAttributes = Attributes?["drinkPortionSize"].AsFloat(0.25f) ?? 0.25f; //base game reads this as an integer
 
             List<ItemStack> corkstacks = [];
 
@@ -390,8 +391,6 @@ namespace ACulinaryArtillery
 
             return true;
         }
-
-        public override float DrinkPortionSize => 0.25f;
 
         public override float GetContainingTransitionModifierContained(IWorldAccessor world, ItemSlot inSlot, EnumTransitionType transType)
         {

--- a/Block/BlockBottle.cs
+++ b/Block/BlockBottle.cs
@@ -391,39 +391,7 @@ namespace ACulinaryArtillery
             return true;
         }
 
-        protected override void tryEatStop(float secondsUsed, ItemSlot slot, EntityAgent byEntity)
-        {
-            if (secondsUsed < 0.95f || byEntity.World is not IServerWorldAccessor) return;
-            if (GetNutritionProperties(byEntity.World, slot.Itemstack, byEntity) is not FoodNutritionProperties nutriProps) return;
-
-            var litres = GetCurrentLitres(slot.Itemstack);
-            var litresToDrink = litres >= 0.25f ? 0.25f : litres;
-
-            var state = UpdateAndGetTransitionState(api.World, slot, EnumTransitionType.Perish);
-
-            var litresMult = litres == 1 ? 0.25f : (litres == 0.75 ? 0.3333f : (litres == 0.5 ? 0.5f : 1.0f));
-
-            byEntity.ReceiveSaturation(nutriProps.Satiety * litresMult * GlobalConstants.FoodSpoilageSatLossMul(state?.TransitionLevel ?? 0, slot.Itemstack, byEntity), nutriProps.FoodCategory);
-            IPlayer? player = (byEntity as EntityPlayer)?.World.PlayerByUid(((EntityPlayer)byEntity).PlayerUID);
-
-            SplitStackAndPerformAction(byEntity, slot, (stack) => TryTakeLiquid(stack, litresToDrink)?.StackSize ?? 0);
-
-            if (nutriProps.Intoxication > 0f)
-            {
-                var intox = byEntity.WatchedAttributes.GetFloat("intoxication");
-                byEntity.WatchedAttributes.SetFloat("intoxication", Math.Min(litresToDrink, intox + (nutriProps.Intoxication * litresMult)));
-            }
-
-            var healthMod = nutriProps.Health * litresMult * GlobalConstants.FoodSpoilageHealthLossMul(state?.TransitionLevel ?? 0, slot.Itemstack, byEntity);
-            if (healthMod != 0) byEntity.ReceiveDamage(new() { Source = EnumDamageSource.Internal, Type = healthMod > 0 ? EnumDamageType.Heal : EnumDamageType.Poison }, Math.Abs(healthMod));
-
-            slot.MarkDirty();
-            player?.InventoryManager.BroadcastHotbarSlot();
-
-            if (GetCurrentLitres(slot.Itemstack) == 0) SetContent(slot.Itemstack, null); //null it out
-
-            return;
-        }
+        public override float DrinkPortionSize => 0.25f;
 
         public override float GetContainingTransitionModifierContained(IWorldAccessor world, ItemSlot inSlot, EnumTransitionType transType)
         {

--- a/assets/aculinaryartillery/blocktypes/bottles/claybottle-fired.json
+++ b/assets/aculinaryartillery/blocktypes/bottles/claybottle-fired.json
@@ -8,16 +8,17 @@
 	"class": "BlockBottle",
 	"creativeinventory": { "general": [ "*" ], "aculinaryartillery": ["*"] },
 	"attributes": {
+		"drinkPortionSize": 0.25,
 		"shelvable": true,
-		"handbook": { 
-          "groupBy": [ "bottle-clay-*-{type}" ],
-          "extraSections": [
-            {
-              "title": "aculinaryartillery:block-handbooktitle-bottle",
-              "text": "aculinaryartillery:block-handbooktext-bottle"
-            }
-          ]
-        },
+		"handbook": {
+			"groupBy": [ "bottle-clay-*-{type}" ],
+			"extraSections": [
+				{
+					"title": "aculinaryartillery:block-handbooktitle-bottle",
+					"text": "aculinaryartillery:block-handbooktext-bottle"
+				}
+			]
+		},
 		"minFill": 0.21,
 		"maxFill": 3.81,
 		"minFillSideways": 6.7,

--- a/assets/aculinaryartillery/blocktypes/bottles/glassbottle.json
+++ b/assets/aculinaryartillery/blocktypes/bottles/glassbottle.json
@@ -8,16 +8,17 @@
 	"class": "BlockBottle",
 	"creativeinventory": { "general": [ "*" ], "aculinaryartillery": ["*"] },
 	"attributes": {
+		"drinkPortionSize": 0.25,
 		"shelvable": true,
-		"handbook": { 
-          "groupBy": [ "bottle-glass-*-{type}" ],
-          "extraSections": [
-            {
-              "title": "aculinaryartillery:block-handbooktitle-bottle",
-              "text": "aculinaryartillery:block-handbooktext-bottle"
-            }
-          ]
-        },
+		"handbook": {
+			"groupBy": [ "bottle-glass-*-{type}" ],
+			"extraSections": [
+				{
+					"title": "aculinaryartillery:block-handbooktitle-bottle",
+					"text": "aculinaryartillery:block-handbooktext-bottle"
+				}
+			]
+		},
 		"minFill": 0.21,
 		"maxFill": 3.81,
 		"minFillSideways": 6.7,


### PR DESCRIPTION
Remove tryEatStop override and use DrinkPortionSize instead (the drink portion size was the only real change from what I could tell)

This doesn't really change anything functionally, but it's cleaner and increases compatibility with mods that hook into the base method.
(I noticed this because I was working on cleaning up / refactoring some old HoD methods, and noticed there is a separate patch specifically for ACA because of this override)